### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.2](https://github.com/gitehr/gitehr/compare/v0.2.1...v0.2.2) - 2026-06-28
+
+### Added
+
+- *(config)* add default store config
+
+### Fixed
+
+- *(ci)* satisfy clippy for config
+
+### Other
+
+- *(mcp)* fold server into gitehr binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "gitehr"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 authors = ["Marcus Baw"]
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `gitehr`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/gitehr/gitehr/compare/v0.2.1...v0.2.2) - 2026-06-28

### Added

- *(config)* add default store config

### Fixed

- *(ci)* satisfy clippy for config

### Other

- *(mcp)* fold server into gitehr binary
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).