### PR TITLE
[codex] add completions installer

### DIFF
--- a/cli/src/commands/completions.rs
+++ b/cli/src/commands/completions.rs
@@ -1,10 +1,126 @@
 // SPDX-FileCopyrightText: 2026 Marcus Baw and Baw Medical Ltd
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use clap::Command;
+use anyhow::{Context, Result, anyhow};
+use clap::{Command, Subcommand};
 use clap_complete::{Shell, generate};
-use std::io;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
 
-pub fn run(shell: Shell, cmd: &mut Command) {
-    generate(shell, cmd, "gitehr", &mut io::stdout());
+#[derive(Clone, Debug, Subcommand)]
+pub enum CompletionCommand {
+    /// Install completions for the current user.
+    Install {
+        /// Shell to install completions for. Detected from $SHELL when omitted.
+        #[arg(long)]
+        shell: Option<Shell>,
+
+        /// Completion directory to write to.
+        #[arg(long, short = 'd')]
+        dir: Option<PathBuf>,
+    },
+}
+
+pub fn run(
+    command: Option<CompletionCommand>,
+    shell: Option<Shell>,
+    dir: Option<&Path>,
+    cmd: &mut Command,
+) -> Result<()> {
+    match command {
+        Some(CompletionCommand::Install { shell, dir }) => {
+            let shell = shell.or_else(detect_shell).ok_or_else(|| {
+                anyhow!("could not detect shell; pass --shell bash|zsh|fish|powershell|elvish")
+            })?;
+            let dir = dir
+                .map(Ok)
+                .unwrap_or_else(|| default_completion_dir(shell))?;
+            write_completion(shell, cmd, &dir)?;
+            print_install_note(shell, &dir);
+        }
+        None => {
+            let shell =
+                shell.ok_or_else(|| anyhow!("missing shell; try `gitehr completions install`"))?;
+            if let Some(dir) = dir {
+                write_completion(shell, cmd, dir)?;
+            } else {
+                generate(shell, cmd, "gitehr", &mut std::io::stdout());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn write_completion(shell: Shell, cmd: &mut Command, dir: &Path) -> Result<PathBuf> {
+    fs::create_dir_all(dir)
+        .with_context(|| format!("creating completion directory {}", dir.display()))?;
+    let path = dir.join(completion_filename(shell));
+    let mut file = fs::File::create(&path)
+        .with_context(|| format!("creating completion file {}", path.display()))?;
+    generate(shell, cmd, "gitehr", &mut file);
+    println!("Completion script written to: {}", path.display());
+    Ok(path)
+}
+
+fn completion_filename(shell: Shell) -> &'static str {
+    match shell {
+        Shell::Bash => "gitehr",
+        Shell::Zsh => "_gitehr",
+        Shell::Fish => "gitehr.fish",
+        Shell::PowerShell => "gitehr.ps1",
+        Shell::Elvish => "gitehr.elv",
+        _ => "gitehr.completion",
+    }
+}
+
+fn detect_shell() -> Option<Shell> {
+    let shell = env::var("SHELL").ok()?;
+    let name = Path::new(&shell).file_name()?.to_string_lossy();
+    match name.as_ref() {
+        "bash" => Some(Shell::Bash),
+        "zsh" => Some(Shell::Zsh),
+        "fish" => Some(Shell::Fish),
+        "elvish" => Some(Shell::Elvish),
+        _ => None,
+    }
+}
+
+fn default_completion_dir(shell: Shell) -> Result<PathBuf> {
+    let home = home_dir().ok_or_else(|| anyhow!("could not determine home directory"))?;
+    Ok(match shell {
+        Shell::Bash => env::var_os("XDG_DATA_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".local/share"))
+            .join("bash-completion/completions"),
+        Shell::Zsh => home.join(".zfunc"),
+        Shell::Fish => env::var_os("XDG_CONFIG_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".config"))
+            .join("fish/completions"),
+        Shell::PowerShell => home.join(".config/powershell/completions"),
+        Shell::Elvish => home.join(".elvish/lib"),
+        _ => home.join(".local/share/gitehr/completions"),
+    })
+}
+
+fn home_dir() -> Option<PathBuf> {
+    env::var_os("HOME")
+        .or_else(|| env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+fn print_install_note(shell: Shell, dir: &Path) {
+    match shell {
+        Shell::Zsh => {
+            println!("Add this before `compinit` in ~/.zshrc if it is not already there:");
+            println!("  fpath=({} $fpath)", dir.display());
+            println!("Then restart zsh or run `autoload -Uz compinit && compinit`.");
+        }
+        Shell::PowerShell => {
+            println!("Add this to your PowerShell profile if it is not already there:");
+            println!("  . {}/gitehr.ps1", dir.display());
+        }
+        _ => println!("Restart your shell to load the updated completions."),
+    }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -105,16 +105,19 @@ enum Commands {
         long_about = r#"Generate shell completions for gitehr.
 
 Examples:
+  gitehr completions install
+  gitehr completions zsh --dir ~/.zfunc
   gitehr completions bash > ~/.local/share/bash-completion/completions/gitehr
-  gitehr completions zsh > "${fpath[1]}/_gitehr"
-  gitehr completions fish > ~/.config/fish/completions/gitehr.fish
-  gitehr completions powershell | Out-File -Append $PROFILE
 
 Restart your shell after installing completions."#
     )]
     Completions {
+        #[command(subcommand)]
+        command: Option<commands::completions::CompletionCommand>,
         #[arg(help = "Shell type (bash, zsh, fish, powershell)")]
-        shell: clap_complete::Shell,
+        shell: Option<clap_complete::Shell>,
+        #[arg(long, short = 'd', help = "Output directory")]
+        dir: Option<PathBuf>,
     },
     /// List installed plugins (gitehr-<command> executables on PATH)
     Plugins,
@@ -169,9 +172,13 @@ fn main() -> Result<()> {
         Commands::Upgrade => commands::upgrade::run()?,
         Commands::UpgradeBinary => commands::upgrade_binary::run()?,
         Commands::Version => commands::version::run(),
-        Commands::Completions { shell } => {
+        Commands::Completions {
+            command,
+            shell,
+            dir,
+        } => {
             let mut cmd = Cli::command();
-            commands::completions::run(shell, &mut cmd);
+            commands::completions::run(command, shell, dir.as_deref(), &mut cmd)?;
         }
         Commands::Plugins => commands::plugin::list(&builtins)?,
         Commands::External(args) => commands::plugin::run(args)?,

--- a/cli/tests/completions.rs
+++ b/cli/tests/completions.rs
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 Marcus Baw and Baw Medical Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::process::Command;
+
+#[test]
+fn completions_generate_and_install() {
+    let bin = env!("CARGO_BIN_EXE_gitehr");
+    let out_dir =
+        std::env::temp_dir().join(format!("gitehr-completions-test-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&out_dir);
+
+    let output = Command::new(bin)
+        .args(["completions", "bash"])
+        .output()
+        .expect("run gitehr completions bash");
+    assert!(output.status.success());
+    let bash = String::from_utf8(output.stdout).expect("bash completions are utf8");
+    assert!(bash.contains("complete"));
+    assert!(bash.contains("completions"));
+
+    let output = Command::new(bin)
+        .args([
+            "completions",
+            "install",
+            "--shell",
+            "zsh",
+            "--dir",
+            out_dir.to_str().expect("temp path"),
+        ])
+        .output()
+        .expect("run gitehr completions install");
+    assert!(output.status.success());
+    assert!(out_dir.join("_gitehr").exists());
+}

--- a/docs/cli/completions.md
+++ b/docs/cli/completions.md
@@ -2,24 +2,34 @@
 
 ```text
 gitehr completions <shell>
+gitehr completions --dir <path> <shell>
+gitehr completions install [--shell <shell>] [--dir <path>]
 ```
 
-Generates shell completion scripts. Supported shells: `bash`, `zsh`, `fish`, `powershell`.
+Installs or generates shell completion scripts. Supported shells: `bash`, `zsh`, `fish`, `powershell`.
 
-The script is printed to stdout; redirect it to your shell's completion directory.
+For the current user, prefer the installer:
+
+```bash
+gitehr completions install
+```
+
+It detects your shell, writes the correctly named completion file, and prints any one-time shell setup still needed.
+
+For package managers or custom locations, generate or write a specific shell's completion script:
 
 ```bash
 # bash
-gitehr completions bash > ~/.local/share/bash-completion/completions/gitehr
+gitehr completions --dir ~/.local/share/bash-completion/completions bash
 
 # zsh
-gitehr completions zsh > "${fpath[1]}/_gitehr"
+gitehr completions --dir ~/.zfunc zsh
 
 # fish
-gitehr completions fish > ~/.config/fish/completions/gitehr.fish
+gitehr completions --dir ~/.config/fish/completions fish
 
 # powershell
-gitehr completions powershell | Out-File -Append $PROFILE
+gitehr completions --dir ~/.config/powershell/completions powershell
 ```
 
-Restart your shell after installing the completion script.
+Restart your shell after installing or refreshing the completion script.

--- a/docs/install/cli.md
+++ b/docs/install/cli.md
@@ -54,16 +54,13 @@ You should see a short usage summary and the current GitEHR version.
 
 ## Shell completions
 
-Generate a completion script and save it to your shell's completion directory.
+Install completion scripts for your current shell:
 
 ```sh
-gitehr completions bash > ~/.local/share/bash-completion/completions/gitehr
-gitehr completions zsh > "${fpath[1]}/_gitehr"
-gitehr completions fish > ~/.config/fish/completions/gitehr.fish
-gitehr completions powershell | Out-File -Append $PROFILE
+gitehr completions install
 ```
 
-Restart your shell after installation.
+The installer detects your shell, writes the correctly named completion file, and prints any one-time shell setup still needed. Re-run it after upgrading GitEHR if your package manager or installer did not refresh completions for you.
 
 ## What's next
 


### PR DESCRIPTION
## Summary
- add `gitehr completions install` for the current-user install path
- keep `gitehr completions <shell>` and add `--dir` for package/custom installs
- replace hard-to-remember redirect docs and add a focused integration test

## Validation
- `cargo fmt --all --check`
- `cargo check -p gitehr`
- `cargo run -p gitehr --quiet -- completions bash >/tmp/gitehr.bash`
- `cargo run -p gitehr --quiet -- completions install --shell zsh --dir /tmp/gitehr-completions-test`
- `cargo test -p gitehr completions_generate_and_install`