### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/gitehr/gitehr/compare/v0.2.2...v0.3.0) - 2026-06-29
+
+### Added
+
+- *(cli)* add completions installer
+
 ## [0.2.2](https://github.com/gitehr/gitehr/compare/v0.2.1...v0.2.2) - 2026-06-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "gitehr"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 authors = ["Marcus Baw"]
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `gitehr`: 0.2.2 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `gitehr` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_parameter_count_changed.ron

Failed in:
  gitehr::commands::completions::run now takes 4 parameters instead of 2, in /tmp/.tmpOv8hIK/gitehr/cli/src/commands/completions.rs:25
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/gitehr/gitehr/compare/v0.2.2...v0.3.0) - 2026-06-29

### Added

- *(cli)* add completions installer
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).