### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/gitehr/gitehr/compare/v0.3.0...v0.3.1) - 2026-06-29
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.3.0](https://github.com/gitehr/gitehr/compare/v0.2.2...v0.3.0) - 2026-06-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "gitehr"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 authors = ["Marcus Baw"]
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION



## 🤖 New release

* `gitehr`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/gitehr/gitehr/compare/v0.3.0...v0.3.1) - 2026-06-29

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).