### PR TITLE
docs(site): make families, carers, and pet owners first-class homepage audiences

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -73,7 +73,7 @@ hide:
   <div class="gitehr-band gitehr-band--alt">
     <div class="gitehr-container">
       <h2>Built for the entire ecosystem</h2>
-      <div class="gitehr-grid gitehr-grid--3">
+      <div class="gitehr-grid">
         
         <!-- CLINICIANS -->
         <div class="gitehr-audience">
@@ -85,14 +85,24 @@ hide:
           <p>GitEHR provides a unified view of care across specialists and facilities, reducing medical errors and redundant testing.</p>
         </div>
 
-        <!-- PATIENTS -->
+        <!-- PATIENTS & FAMILIES -->
         <div class="gitehr-audience">
           <div class="gitehr-audience__header">
             <div class="gitehr-audience__icon">P</div>
-            <h3>For Patients</h3>
+            <h3>For Patients &amp; Families</h3>
           </div>
           <p><strong>Your health, in your hands.</strong> You hold the master copy of your record. No more requesting faxed transfers.</p>
-          <p>Grant temporary access to new doctors with a key, and revoke it when you're done. Your privacy is mathematically guaranteed.</p>
+          <p>A self-hoster is usually already caring for more than one record - yourself, your children, or an elderly parent. GitEHR's Store holds them all in one place, under one owner.</p>
+        </div>
+
+        <!-- PET OWNERS -->
+        <div class="gitehr-audience">
+          <div class="gitehr-audience__header">
+            <div class="gitehr-audience__icon">🐾</div>
+            <h3>For Pet Owners</h3>
+          </div>
+          <p><strong>The same record, for the whole family.</strong> Vaccinations, vet visits, and a major surgery, kept in one place you own forever.</p>
+          <p>Pet records use the identical multi-subject Store model as the rest of GitEHR - a low-stakes way to try it before trusting it with your own.</p>
         </div>
 
         <!-- ORGANISATIONS -->

--- a/spec/roadmap.md
+++ b/spec/roadmap.md
@@ -19,7 +19,7 @@ Legend: `[x]` done, `[~]` in progress, `[ ]` not started. This roadmap lists out
 ## Repository and Commands
 
 - [ ] **R6 - Extend Store identifier operations:** add `search`, `link`, `unlink`, `merge`, and `path`, plus the `GITEHR_MPI_PATH` override, as `gitehr store` subcommands.
-- [ ] **R7 - Document the self-hoster on-ramp:** make families, carers, and pet owners first-class audiences in site and GUI onboarding, alongside clinics (ADR-0005).
+- [~] **R7 - Document the self-hoster on-ramp:** make families, carers, and pet owners first-class audiences in site and GUI onboarding, alongside clinics (ADR-0005). Site homepage done (families/carers folded into "For Patients & Families", plus a new "For Pet Owners" card); GUI onboarding has no onboarding flow yet to update (tracked by R63).
 - [ ] **R8 - Align GUI launch behaviour:** prefer the bundled `.gitehr/gitehr-gui`, then `gitehr-gui` on `$PATH`, rather than the current development launcher.
 
 ## GUI and TUI


### PR DESCRIPTION
## Summary

Nightly triage fallback task (roadmap **R7**, per [ADR-0005](spec/adr/0005-store-first-model.md)): the homepage's "Built for the entire ecosystem" section only named Clinicians, Patients, and Organisations, missing the family/carer/pet-owner self-hoster story ADR-0005 calls for:

> Docs gain a first-class self-hoster story - **families and pets** - alongside clinics, on the homepage and audience pages.

- Expanded "For Patients" into **"For Patients & Families"**, naming the multi-subject self-hoster case (yourself, your children, an elderly parent) directly from ADR-0005.
- Added a new **"For Pet Owners"** card, using ADR-0005's own framing of pets as a low-stakes, high-volume, emotionally compelling on-ramp to the same multi-subject Store model.
- Dropped the audience grid's fixed 3-column modifier (`gitehr-grid--3`) so it reflows for four cards using the existing auto-fit grid rules (`gitehr-grid`), rather than adding new CSS.

GUI onboarding (the other half of R7) has no onboarding flow yet to update — there's no GUI onboarding surface today, that's tracked separately by **R63** (five-screen clinical GUI MVP). Marked R7 `[~]` in-progress in `spec/roadmap.md` rather than `[x]` done, to reflect that only the site half is complete.

## Test plan

- [x] `zensical build --strict` in a clean venv (`pip install -r requirements.txt`) — "No issues found".
- [x] Confirmed the built `site/index.html` renders the new "For Pet Owners" card and updated "For Patients & Families" copy.
- [x] Content review: new copy paraphrases ADR-0005's own audience language rather than inventing new claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125gZ4waAVBBxxq13JGSw5W

---
_Generated by [Claude Code](https://claude.ai/code/session_0125gZ4waAVBBxxq13JGSw5W)_