### PR TITLE
chore(deps): update stale npm dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain (stable, with rustfmt and clippy)
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: stable
           components: rustfmt, clippy

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -41,7 +41,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: stable
 

--- a/gui/e2e/package-lock.json
+++ b/gui/e2e/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "e2e",
+  "name": "gitehr-e2e",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "e2e",
+      "name": "gitehr-e2e",
       "version": "1.0.0",
       "devDependencies": {
         "@wdio/cli": "^9.30.0",
-        "@wdio/local-runner": "^9.23.3",
+        "@wdio/local-runner": "^9.30.1",
         "@wdio/mocha-framework": "^9.30.0",
         "@wdio/spec-reporter": "^9.23.3"
       }
@@ -1329,28 +1329,6 @@
         "node": ">=18.20.0"
       }
     },
-    "node_modules/@wdio/cli/node_modules/@wdio/globals": {
-      "version": "9.29.1",
-      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-9.29.1.tgz",
-      "integrity": "sha512-F96BKppx4HGD64v+s57TM4K4zaxqUCg2RXHk6sjB2xrSa7P+d2VYV28ID2ddF7iSodVfPlpa1i2/jy8jMGrU8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.20.0"
-      },
-      "peerDependencies": {
-        "expect-webdriverio": "^5.6.5",
-        "webdriverio": "^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "expect-webdriverio": {
-          "optional": false
-        },
-        "webdriverio": {
-          "optional": false
-        }
-      }
-    },
     "node_modules/@wdio/cli/node_modules/@wdio/logger": {
       "version": "9.29.1",
       "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.29.1.tgz",
@@ -1483,15 +1461,15 @@
       }
     },
     "node_modules/@wdio/config": {
-      "version": "9.23.3",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.23.3.tgz",
-      "integrity": "sha512-tQCT1R6R3hdib7Qb+82Dxgn/sB+CiR8+GS4zyJh5vU0dzLGeYsCo2B5W89VLItvRjveTmsmh8NOQGV2KH0FHTQ==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.30.1.tgz",
+      "integrity": "sha512-55D7g1RBCyHTwMkb4b6sQU0ET5lf5UUM3SgTHDGOo2KHfiydtCqOvfGwzxaf9nv200+QGY6BqI6yD0Ad1VGV0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.23.3",
-        "@wdio/utils": "9.23.3",
+        "@wdio/logger": "9.29.1",
+        "@wdio/types": "9.30.1",
+        "@wdio/utils": "9.30.1",
         "deepmerge-ts": "^7.0.3",
         "glob": "^10.2.2",
         "import-meta-resolve": "^4.0.0",
@@ -1501,32 +1479,109 @@
         "node": ">=18.20.0"
       }
     },
-    "node_modules/@wdio/dot-reporter": {
-      "version": "9.23.3",
-      "resolved": "https://registry.npmjs.org/@wdio/dot-reporter/-/dot-reporter-9.23.3.tgz",
-      "integrity": "sha512-behiP6+SbQDO51GMtJ120X1vvc2I+qEdmTjfEG66e9hYozcg+iiaaPQd9RnCl8GJiU320APA91FXUGkz2ehSVQ==",
+    "node_modules/@wdio/config/node_modules/@wdio/logger": {
+      "version": "9.29.1",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.29.1.tgz",
+      "integrity": "sha512-0ZAEIo6PNyMIJPlOGkIgyOJUjcd0pC8/QHlVAAe1c91/IcjZ1X+k0yidXHaboJdN7dq1XPUacmhRdtua0U5EZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@wdio/reporter": "9.23.3",
-        "@wdio/types": "9.23.3",
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/config/node_modules/@wdio/types": {
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.30.1.tgz",
+      "integrity": "sha512-umKQDbSmu3/ucUsIA5UUTK5gCWnClyVpWz3fC39044rCXQ3zCd1a3GoJibbAITKiwnPFf2yU3LvTa+C78sh9Lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/dot-reporter": {
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@wdio/dot-reporter/-/dot-reporter-9.30.1.tgz",
+      "integrity": "sha512-YPRrKLuubvu9Gh39/fZqXiDM4nAYHqZ0yLlFCrPjHhmR7CX/tfBrMqVBSAHAE6xCrM8Txa193fcIzwzQtGxoFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/reporter": "9.30.1",
+        "@wdio/types": "9.30.1",
         "chalk": "^5.0.1"
       },
       "engines": {
         "node": ">=18.20.0"
       }
     },
+    "node_modules/@wdio/dot-reporter/node_modules/@wdio/logger": {
+      "version": "9.29.1",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.29.1.tgz",
+      "integrity": "sha512-0ZAEIo6PNyMIJPlOGkIgyOJUjcd0pC8/QHlVAAe1c91/IcjZ1X+k0yidXHaboJdN7dq1XPUacmhRdtua0U5EZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/dot-reporter/node_modules/@wdio/reporter": {
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-9.30.1.tgz",
+      "integrity": "sha512-0whWaLfJtOAy3PzbGUxGrCAGitgaUCMe8qUgAuP2l7ess70AXqvp1wJibw74a/Z2giegJlJiAc4PxS0abs9/tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0",
+        "@wdio/logger": "9.29.1",
+        "@wdio/types": "9.30.1",
+        "diff": "^8.0.2",
+        "object-inspect": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/dot-reporter/node_modules/@wdio/types": {
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.30.1.tgz",
+      "integrity": "sha512-umKQDbSmu3/ucUsIA5UUTK5gCWnClyVpWz3fC39044rCXQ3zCd1a3GoJibbAITKiwnPFf2yU3LvTa+C78sh9Lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
     "node_modules/@wdio/globals": {
-      "version": "9.23.0",
-      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-9.23.0.tgz",
-      "integrity": "sha512-OmwPKV8c5ecLqo+EkytN7oUeYfNmRI4uOXGIR1ybP7AK5Zz+l9R0dGfoadEuwi1aZXAL0vwuhtq3p0OL3dfqHQ==",
+      "version": "9.29.1",
+      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-9.29.1.tgz",
+      "integrity": "sha512-F96BKppx4HGD64v+s57TM4K4zaxqUCg2RXHk6sjB2xrSa7P+d2VYV28ID2ddF7iSodVfPlpa1i2/jy8jMGrU8w==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.20.0"
       },
       "peerDependencies": {
-        "expect-webdriverio": "^5.3.4",
+        "expect-webdriverio": "^5.6.5",
         "webdriverio": "^9.0.0"
       },
       "peerDependenciesMeta": {
@@ -1539,22 +1594,52 @@
       }
     },
     "node_modules/@wdio/local-runner": {
-      "version": "9.23.3",
-      "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-9.23.3.tgz",
-      "integrity": "sha512-ToafGHzdszOn8yc2BqUCAw0w9AX6158WKCHe50czZrHL04Q4eMCaqhb4XHY2wltSPPuubqCiPE2OgRssYi2kdQ==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-9.30.1.tgz",
+      "integrity": "sha512-nYacWDfVHolKQIZggbj4pB0Ndtr9YwRnVqdvw7bxT1YdUbGwLdJHJVL3Y/e5S+Cu57ntWI/MdhS0JXFgfBjzhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0",
-        "@wdio/logger": "9.18.0",
+        "@wdio/logger": "9.29.1",
         "@wdio/repl": "9.16.2",
-        "@wdio/runner": "9.23.3",
-        "@wdio/types": "9.23.3",
-        "@wdio/xvfb": "9.23.3",
+        "@wdio/runner": "9.30.1",
+        "@wdio/types": "9.30.1",
+        "@wdio/xvfb": "9.30.1",
         "exit-hook": "^4.0.0",
-        "expect-webdriverio": "^5.3.4",
+        "expect-webdriverio": "^5.6.5",
         "split2": "^4.1.0",
         "stream-buffers": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/local-runner/node_modules/@wdio/logger": {
+      "version": "9.29.1",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.29.1.tgz",
+      "integrity": "sha512-0ZAEIo6PNyMIJPlOGkIgyOJUjcd0pC8/QHlVAAe1c91/IcjZ1X+k0yidXHaboJdN7dq1XPUacmhRdtua0U5EZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/local-runner/node_modules/@wdio/types": {
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.30.1.tgz",
+      "integrity": "sha512-umKQDbSmu3/ucUsIA5UUTK5gCWnClyVpWz3fC39044rCXQ3zCd1a3GoJibbAITKiwnPFf2yU3LvTa+C78sh9Lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
       },
       "engines": {
         "node": ">=18.20.0"
@@ -1652,9 +1737,9 @@
       }
     },
     "node_modules/@wdio/protocols": {
-      "version": "9.23.3",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.23.3.tgz",
-      "integrity": "sha512-QfA3Gfl9/3QRX1FnH7x2+uZrgpkwYcksgk1bxGLzl/E0Qefp3BkhgHAfSB1+iKsiYIw9iFOLVx+x+zh0F4BSeg==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.30.1.tgz",
+      "integrity": "sha512-kV0eHy6scYoXqZuAWvtYS5ebkyIF2/JdApSEu6kIdS2EppnROuvUzsNjTUzNkT6gk+0Ib9C/CbOqiuyZuhBUcA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1689,28 +1774,28 @@
       }
     },
     "node_modules/@wdio/runner": {
-      "version": "9.23.3",
-      "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-9.23.3.tgz",
-      "integrity": "sha512-CnN4JubPmgVjWS9+S4nR8iDrVpjzsrClVlrAkhyG7+GF6PqzqMUpUABkFh7WlBxOATyxky/q6JCqgdFE+teVIA==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-9.30.1.tgz",
+      "integrity": "sha512-mZIqnpUupSFUpw4TH+aMU7ecyi2dZuSwJ0vQHC7oYCL4gCOlUgZ8+JRe2ZGvQdp/9GfaUSr7H8/sB86znkggdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.11.28",
-        "@wdio/config": "9.23.3",
-        "@wdio/dot-reporter": "9.23.3",
-        "@wdio/globals": "9.23.0",
-        "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.23.3",
-        "@wdio/utils": "9.23.3",
+        "@wdio/config": "9.30.1",
+        "@wdio/dot-reporter": "9.30.1",
+        "@wdio/globals": "9.29.1",
+        "@wdio/logger": "9.29.1",
+        "@wdio/types": "9.30.1",
+        "@wdio/utils": "9.30.1",
         "deepmerge-ts": "^7.0.3",
-        "webdriver": "9.23.3",
-        "webdriverio": "9.23.3"
+        "webdriver": "9.30.1",
+        "webdriverio": "9.30.1"
       },
       "engines": {
         "node": ">=18.20.0"
       },
       "peerDependencies": {
-        "expect-webdriverio": "^5.3.4",
+        "expect-webdriverio": "^5.6.5",
         "webdriverio": "^9.0.0"
       },
       "peerDependenciesMeta": {
@@ -1720,6 +1805,36 @@
         "webdriverio": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@wdio/runner/node_modules/@wdio/logger": {
+      "version": "9.29.1",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.29.1.tgz",
+      "integrity": "sha512-0ZAEIo6PNyMIJPlOGkIgyOJUjcd0pC8/QHlVAAe1c91/IcjZ1X+k0yidXHaboJdN7dq1XPUacmhRdtua0U5EZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/runner/node_modules/@wdio/types": {
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.30.1.tgz",
+      "integrity": "sha512-umKQDbSmu3/ucUsIA5UUTK5gCWnClyVpWz3fC39044rCXQ3zCd1a3GoJibbAITKiwnPFf2yU3LvTa+C78sh9Lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
       }
     },
     "node_modules/@wdio/spec-reporter": {
@@ -1753,19 +1868,19 @@
       }
     },
     "node_modules/@wdio/utils": {
-      "version": "9.23.3",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.23.3.tgz",
-      "integrity": "sha512-LO/cTpOcb3r49psjmWTxjFduHUMHDOhVfSzL1gfBCS5cGv6h3hAWOYw/94OrxLn1SIOgZu/hyLwf3SWeZB529g==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.30.1.tgz",
+      "integrity": "sha512-V+JE4G6ZO9ubdjDfHDHgp/2EWs5WCXk4IT2c2ZMoWy2qALqq4wqaeZ0ce05c3z0+N+8+xMS/Q9donDiIY1yk5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@puppeteer/browsers": "^2.2.0",
-        "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.23.3",
+        "@wdio/logger": "9.29.1",
+        "@wdio/types": "9.30.1",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^7.0.3",
         "edgedriver": "^6.1.2",
-        "geckodriver": "^6.1.0",
+        "geckodriver": "^6.1.1",
         "get-port": "^7.0.0",
         "import-meta-resolve": "^4.0.0",
         "locate-app": "^2.2.24",
@@ -1778,17 +1893,64 @@
         "node": ">=18.20.0"
       }
     },
-    "node_modules/@wdio/xvfb": {
-      "version": "9.23.3",
-      "resolved": "https://registry.npmjs.org/@wdio/xvfb/-/xvfb-9.23.3.tgz",
-      "integrity": "sha512-m0uITSBWk5hZyBdCFChpU05rkZCrTlu19qOHlSoJq19HX7m7mLbAz3tuu4SE+6jSw/E16I99zTC5S1bpxj7bEg==",
+    "node_modules/@wdio/utils/node_modules/@wdio/logger": {
+      "version": "9.29.1",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.29.1.tgz",
+      "integrity": "sha512-0ZAEIo6PNyMIJPlOGkIgyOJUjcd0pC8/QHlVAAe1c91/IcjZ1X+k0yidXHaboJdN7dq1XPUacmhRdtua0U5EZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@wdio/logger": "9.18.0"
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/utils/node_modules/@wdio/types": {
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.30.1.tgz",
+      "integrity": "sha512-umKQDbSmu3/ucUsIA5UUTK5gCWnClyVpWz3fC39044rCXQ3zCd1a3GoJibbAITKiwnPFf2yU3LvTa+C78sh9Lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/xvfb": {
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@wdio/xvfb/-/xvfb-9.30.1.tgz",
+      "integrity": "sha512-ZvGUg+udJWsVmE8yC26pMMCYmvblBEItRxZ6MW/Ucf710dJUs14sY23LM9m33v/uqCYim5EsSNSxV0SaKTbveQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/logger": "9.29.1"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/xvfb/node_modules/@wdio/logger": {
+      "version": "9.29.1",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.29.1.tgz",
+      "integrity": "sha512-0ZAEIo6PNyMIJPlOGkIgyOJUjcd0pC8/QHlVAAe1c91/IcjZ1X+k0yidXHaboJdN7dq1XPUacmhRdtua0U5EZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
       }
     },
     "node_modules/@zip.js/zip.js": {
@@ -6432,43 +6594,73 @@
       }
     },
     "node_modules/webdriver": {
-      "version": "9.23.3",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.23.3.tgz",
-      "integrity": "sha512-8FdXOhzkxqDI6F1dyIsQONhKLDZ9HPSEwNBnH3bD1cHnj/6nVvyYrUtDPo/+J324BuwOa1IVTH3m8mb3B2hTlA==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.30.1.tgz",
+      "integrity": "sha512-qvtOsFiS0v3rrDPp+saWI8WQdOotT7nsPIFaML0T/uRUwr4QPjaFNbY+ZQwfzv07BQdpVGwiUEeLws5piVlEgA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0",
         "@types/ws": "^8.5.3",
-        "@wdio/config": "9.23.3",
-        "@wdio/logger": "9.18.0",
-        "@wdio/protocols": "9.23.3",
-        "@wdio/types": "9.23.3",
-        "@wdio/utils": "9.23.3",
+        "@wdio/config": "9.30.1",
+        "@wdio/logger": "9.29.1",
+        "@wdio/protocols": "9.30.1",
+        "@wdio/types": "9.30.1",
+        "@wdio/utils": "9.30.1",
         "deepmerge-ts": "^7.0.3",
         "https-proxy-agent": "^7.0.6",
-        "undici": "^6.21.3",
-        "ws": "^8.8.0"
+        "undici": "^6.27.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/webdriver/node_modules/@wdio/logger": {
+      "version": "9.29.1",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.29.1.tgz",
+      "integrity": "sha512-0ZAEIo6PNyMIJPlOGkIgyOJUjcd0pC8/QHlVAAe1c91/IcjZ1X+k0yidXHaboJdN7dq1XPUacmhRdtua0U5EZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/webdriver/node_modules/@wdio/types": {
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.30.1.tgz",
+      "integrity": "sha512-umKQDbSmu3/ucUsIA5UUTK5gCWnClyVpWz3fC39044rCXQ3zCd1a3GoJibbAITKiwnPFf2yU3LvTa+C78sh9Lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
       },
       "engines": {
         "node": ">=18.20.0"
       }
     },
     "node_modules/webdriverio": {
-      "version": "9.23.3",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.23.3.tgz",
-      "integrity": "sha512-1dhMsBx/GLHJsDLhg/xuEQ48JZPrbldz7qdFT+MXQZADj9CJ4bJywWtVBME648MmVMfgDvLc5g2ThGIOupSLvQ==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.30.1.tgz",
+      "integrity": "sha512-HvoMHVPj1Ky04h0kEELKilWuzAi0Ctpmfw5V7LStQmOzbXkzfxxMutSB3SezJAYCWCnZ6zsEw7TdDWubWGY7qA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",
-        "@wdio/config": "9.23.3",
-        "@wdio/logger": "9.18.0",
-        "@wdio/protocols": "9.23.3",
+        "@wdio/config": "9.30.1",
+        "@wdio/logger": "9.29.1",
+        "@wdio/protocols": "9.30.1",
         "@wdio/repl": "9.16.2",
-        "@wdio/types": "9.23.3",
-        "@wdio/utils": "9.23.3",
+        "@wdio/types": "9.30.1",
+        "@wdio/utils": "9.30.1",
         "archiver": "^7.0.1",
         "aria-query": "^5.3.0",
         "cheerio": "^1.0.0-rc.12",
@@ -6485,7 +6677,7 @@
         "rgb2hex": "0.2.5",
         "serialize-error": "^12.0.0",
         "urlpattern-polyfill": "^10.0.0",
-        "webdriver": "9.23.3"
+        "webdriver": "9.30.1"
       },
       "engines": {
         "node": ">=18.20.0"
@@ -6497,6 +6689,36 @@
         "puppeteer-core": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webdriverio/node_modules/@wdio/logger": {
+      "version": "9.29.1",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.29.1.tgz",
+      "integrity": "sha512-0ZAEIo6PNyMIJPlOGkIgyOJUjcd0pC8/QHlVAAe1c91/IcjZ1X+k0yidXHaboJdN7dq1XPUacmhRdtua0U5EZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/webdriverio/node_modules/@wdio/types": {
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.30.1.tgz",
+      "integrity": "sha512-umKQDbSmu3/ucUsIA5UUTK5gCWnClyVpWz3fC39044rCXQ3zCd1a3GoJibbAITKiwnPFf2yU3LvTa+C78sh9Lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
       }
     },
     "node_modules/whatwg-encoding": {

--- a/gui/e2e/package.json
+++ b/gui/e2e/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@wdio/cli": "^9.30.0",
-    "@wdio/local-runner": "^9.23.3",
+    "@wdio/local-runner": "^9.30.1",
     "@wdio/mocha-framework": "^9.30.0",
     "@wdio/spec-reporter": "^9.23.3"
   }

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2",
-        "@types/react": "^19.2.17",
+        "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
         "@vitejs/plugin-react": "^5.1.2",
         "typescript": "^5.9.3",
@@ -1586,9 +1586,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/gui/package.json
+++ b/gui/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",
-    "@types/react": "^19.2.17",
+    "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^5.1.2",
     "typescript": "^5.9.3",


### PR DESCRIPTION
Replaces stale Dependabot PRs #125 and #128, which cannot rebase because their historic update group was removed from the Dependabot configuration.\n\nUpdates @types/react to 19.2.18 and @wdio/local-runner to 9.30.1, regenerating both lockfiles.\n\nValidation:\n- npm ci --ignore-scripts and npm run build in gui\n- npm ci --ignore-scripts in gui/e2e\n- cargo fmt --all --check\n- cargo clippy --all-targets -- -D warnings