### PR TITLE
chore(deps): update WebdriverIO CLI

### DIFF
--- a/gui/e2e/package-lock.json
+++ b/gui/e2e/package-lock.json
@@ -8,7 +8,7 @@
       "name": "gitehr-e2e",
       "version": "1.0.0",
       "devDependencies": {
-        "@wdio/cli": "^9.30.0",
+        "@wdio/cli": "^9.30.1",
         "@wdio/local-runner": "^9.30.1",
         "@wdio/mocha-framework": "^9.30.0",
         "@wdio/spec-reporter": "^9.23.3"
@@ -1276,23 +1276,23 @@
       }
     },
     "node_modules/@wdio/cli": {
-      "version": "9.30.0",
-      "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-9.30.0.tgz",
-      "integrity": "sha512-e5IqOvfjnyMfSYM6c++qe66kwMw24TA11b/sYDa3oPsHps06JaRzFqM4U0HZIUa+9QpNheat87VYJWrsRCKv1g==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-9.30.1.tgz",
+      "integrity": "sha512-Xrka5FQO/z2hc8vURfUSpGc2W99APCtSjLD2QJtN2C83FtrkyWq2nQDQWNYfwn9V1sSo6+7AZ4UbpGmJX9ap6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/snapshot": "^2.1.1",
-        "@wdio/config": "9.30.0",
+        "@wdio/config": "9.30.1",
         "@wdio/globals": "9.29.1",
         "@wdio/logger": "9.29.1",
-        "@wdio/protocols": "9.30.0",
-        "@wdio/types": "9.29.1",
-        "@wdio/utils": "9.30.0",
+        "@wdio/protocols": "9.30.1",
+        "@wdio/types": "9.30.1",
+        "@wdio/utils": "9.30.1",
         "async-exit-hook": "^2.0.1",
         "chalk": "^5.4.1",
         "chokidar": "^4.0.0",
-        "create-wdio": "9.30.0",
+        "create-wdio": "9.30.1",
         "dotenv": "^17.2.0",
         "import-meta-resolve": "^4.0.0",
         "lodash.flattendeep": "^4.4.0",
@@ -1300,30 +1300,11 @@
         "lodash.union": "^4.6.0",
         "read-pkg-up": "^10.0.0",
         "tsx": "^4.7.2",
-        "webdriverio": "9.30.0",
+        "webdriverio": "9.30.1",
         "yargs": "^17.7.2"
       },
       "bin": {
         "wdio": "bin/wdio.js"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/@wdio/config": {
-      "version": "9.30.0",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.30.0.tgz",
-      "integrity": "sha512-pH/Y1F4QVIsx33xyli8+9HCr4HRuOeUk8j/lqNBuuUzbvduYRCLmNkZqxRsLnRth8wrlPdzA8Hq+PPLwJWrceA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@wdio/logger": "9.29.1",
-        "@wdio/types": "9.29.1",
-        "@wdio/utils": "9.30.0",
-        "deepmerge-ts": "^7.0.3",
-        "glob": "^10.2.2",
-        "import-meta-resolve": "^4.0.0",
-        "jiti": "^2.6.1"
       },
       "engines": {
         "node": ">=18.20.0"
@@ -1346,17 +1327,10 @@
         "node": ">=18.20.0"
       }
     },
-    "node_modules/@wdio/cli/node_modules/@wdio/protocols": {
-      "version": "9.30.0",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.30.0.tgz",
-      "integrity": "sha512-VDKCTw3GVdqUw1+fXAY4FUOSt+a3/r7T2O34d5HAaZLfI6QHacsU7/N0Sv3w/QgWU6yj3WkXElXq1oSWF1XcBw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@wdio/cli/node_modules/@wdio/types": {
-      "version": "9.29.1",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.29.1.tgz",
-      "integrity": "sha512-jp8jgMv6TS35G96YzHZxw3PVN0Dz6xQ6tnMAicndAJ8Jt9AIXb0ywIse4TjaFywakO3dLoEhlyA3ZtR26vmt+w==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.30.1.tgz",
+      "integrity": "sha512-umKQDbSmu3/ucUsIA5UUTK5gCWnClyVpWz3fC39044rCXQ3zCd1a3GoJibbAITKiwnPFf2yU3LvTa+C78sh9Lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1364,100 +1338,6 @@
       },
       "engines": {
         "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/@wdio/utils": {
-      "version": "9.30.0",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.30.0.tgz",
-      "integrity": "sha512-MhTx8jKOtspogeMUmASFsmL6vRetwCpvfcAFHauYZ62UzPjFwHThIXorzoG90mrcS9Yl+c8Sj9BfX+bdxwXfsg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@puppeteer/browsers": "^2.2.0",
-        "@wdio/logger": "9.29.1",
-        "@wdio/types": "9.29.1",
-        "decamelize": "^6.0.0",
-        "deepmerge-ts": "^7.0.3",
-        "edgedriver": "^6.1.2",
-        "geckodriver": "^6.1.1",
-        "get-port": "^7.0.0",
-        "import-meta-resolve": "^4.0.0",
-        "locate-app": "^2.2.24",
-        "mitt": "^3.0.1",
-        "safaridriver": "^1.0.0",
-        "split2": "^4.2.0",
-        "wait-port": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/webdriver": {
-      "version": "9.30.0",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.30.0.tgz",
-      "integrity": "sha512-DisY5E8p5zAZyl8pee08p4Vlc91c94Am9oswZaNCgZH5Ewm//FoCZ+tHNppENqooCYjfa/upATbFqGOLuXQkrw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0",
-        "@types/ws": "^8.5.3",
-        "@wdio/config": "9.30.0",
-        "@wdio/logger": "9.29.1",
-        "@wdio/protocols": "9.30.0",
-        "@wdio/types": "9.29.1",
-        "@wdio/utils": "9.30.0",
-        "deepmerge-ts": "^7.0.3",
-        "https-proxy-agent": "^7.0.6",
-        "undici": "^6.27.0",
-        "ws": "^8.21.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/webdriverio": {
-      "version": "9.30.0",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.30.0.tgz",
-      "integrity": "sha512-cmV/uSbCvnJ99QejGPVGlzb9MjiSYUts8VjdESnDKvA7JvRMIJK0l807Js7HDK/g6KG7j+D2apsFHGlT7W5UeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.11.30",
-        "@types/sinonjs__fake-timers": "^8.1.5",
-        "@wdio/config": "9.30.0",
-        "@wdio/logger": "9.29.1",
-        "@wdio/protocols": "9.30.0",
-        "@wdio/repl": "9.16.2",
-        "@wdio/types": "9.29.1",
-        "@wdio/utils": "9.30.0",
-        "archiver": "^7.0.1",
-        "aria-query": "^5.3.0",
-        "cheerio": "^1.0.0-rc.12",
-        "css-shorthand-properties": "^1.1.1",
-        "css-value": "^0.0.1",
-        "grapheme-splitter": "^1.0.4",
-        "htmlfy": "^0.8.1",
-        "is-plain-obj": "^4.1.0",
-        "jszip": "^3.10.1",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.zip": "^4.2.0",
-        "query-selector-shadow-dom": "^1.0.1",
-        "resq": "^1.11.0",
-        "rgb2hex": "0.2.5",
-        "serialize-error": "^12.0.0",
-        "urlpattern-polyfill": "^10.0.0",
-        "webdriver": "9.30.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      },
-      "peerDependencies": {
-        "puppeteer-core": ">=22.x || <=24.x"
-      },
-      "peerDependenciesMeta": {
-        "puppeteer-core": {
-          "optional": true
-        }
       }
     },
     "node_modules/@wdio/config": {
@@ -2714,9 +2594,9 @@
       }
     },
     "node_modules/create-wdio": {
-      "version": "9.30.0",
-      "resolved": "https://registry.npmjs.org/create-wdio/-/create-wdio-9.30.0.tgz",
-      "integrity": "sha512-rmlMhGxT+s+mnAt+GWUhwf/h9CalN1Qy/LXE6u7IUkw2HdpcimYZOFCQ15bujE+Bm0/rfH9jFz9Tn08xtln4nw==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/create-wdio/-/create-wdio-9.30.1.tgz",
+      "integrity": "sha512-v32oaidXLZqQv7jdamm+KshYoZNLMd5pNyfw3zDr8XeEulmxp16ZGL0b4iPpZkOCR457R44Q08eFLq30Rm1TSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/gui/e2e/package.json
+++ b/gui/e2e/package.json
@@ -9,7 +9,7 @@
     "test:with-repo": "E2E_WITH_REPO=true wdio run wdio.conf.js"
   },
   "devDependencies": {
-    "@wdio/cli": "^9.30.0",
+    "@wdio/cli": "^9.30.1",
     "@wdio/local-runner": "^9.30.1",
     "@wdio/mocha-framework": "^9.30.0",
     "@wdio/spec-reporter": "^9.23.3"


### PR DESCRIPTION
Replaces #134, which conflicted with the already-merged local-runner update.\n\nUpdates @wdio/cli to 9.30.1 and regenerates its lockfile.\n\nValidation:\n- npm ci --ignore-scripts in gui/e2e\n- npx wdio --version