### PR TITLE
Wire up `gitehr gui` to prefer bundled/PATH binary (R8)

### DIFF
--- a/cli/src/commands/gui.rs
+++ b/cli/src/commands/gui.rs
@@ -9,10 +9,9 @@ fn is_gitehr_repo() -> bool {
     PathBuf::from(".gitehr").exists()
 }
 
-// Locates a bundled or installed GUI binary for the release launch path
-// described in `run()`. Not yet wired up (dev mode runs `npm run tauri dev`).
-#[allow(dead_code)]
-fn find_gui_binary() -> Option<PathBuf> {
+/// Locates a bundled or installed GUI binary for the release launch path
+/// described in `run()`.
+pub fn find_gui_binary() -> Option<PathBuf> {
     let bundled_path = PathBuf::from(".gitehr/gitehr-gui");
     if bundled_path.exists() {
         return Some(bundled_path);
@@ -32,23 +31,34 @@ fn find_gui_binary() -> Option<PathBuf> {
     None
 }
 
-/// Launch the GitEHR GUI application
-/// For development, launches with: WEBKIT_DISABLE_DMABUF_RENDERER=1 npm run tauri dev
-/// For release, should launch the compiled, OS-appropriate GUI binary
+/// Launch the GitEHR GUI application.
+///
+/// Prefers a bundled GUI binary at `.gitehr/gitehr-gui` (or `.gitehr/gitehr-gui.exe`
+/// on Windows), then falls back to `gitehr-gui` on `$PATH`. If neither is found,
+/// prints guidance on how to install or build one. For running the GUI from
+/// source during development, use `s/gui-dev` instead of this command.
 pub fn run() -> Result<()> {
     if !is_gitehr_repo() {
         println!("Warning: Not in a GitEHR repository. Opening GUI without repository context.");
     }
-    // Development mode: run tauri dev
-    let status = Command::new("npm")
-        .arg("run")
-        .arg("tauri")
-        .arg("dev")
-        .env("WEBKIT_DISABLE_DMABUF_RENDERER", "1")
-        .current_dir("gui")
-        .status()?;
-    if !status.success() {
-        anyhow::bail!("Failed to launch GUI in dev mode.");
+
+    match find_gui_binary() {
+        Some(path) => {
+            let status = Command::new(path).status()?;
+            if !status.success() {
+                anyhow::bail!("GUI exited with an error.");
+            }
+            Ok(())
+        }
+        None => {
+            println!("No GitEHR GUI binary found.");
+            println!();
+            println!(
+                "Looked for a bundled binary at .gitehr/gitehr-gui and for gitehr-gui on $PATH."
+            );
+            println!("To install the GUI, see https://gitehr.org/install/gui/");
+            println!("To build and run it from source, run `s/gui-dev` from the repository root.");
+            Ok(())
+        }
     }
-    Ok(())
 }

--- a/cli/tests/commands/gui.rs
+++ b/cli/tests/commands/gui.rs
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 Marcus Baw and Baw Medical Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use serial_test::serial;
+use std::fs;
+use tempfile::tempdir;
+
+use gitehr::commands::gui::find_gui_binary;
+
+fn setup() -> tempfile::TempDir {
+    let temp_dir = tempdir().unwrap();
+    let _ = std::env::set_current_dir(&temp_dir);
+    temp_dir
+}
+
+/// Prepends `dir` to `$PATH` and returns the previous value, so the caller
+/// can restore it once the test is done with it.
+fn prepend_to_path(dir: &std::path::Path) -> String {
+    let original = std::env::var("PATH").unwrap_or_default();
+    let mut paths = vec![dir.to_path_buf()];
+    paths.extend(std::env::split_paths(&original));
+    let joined = std::env::join_paths(paths).unwrap();
+    unsafe { std::env::set_var("PATH", &joined) };
+    original
+}
+
+#[cfg(unix)]
+fn make_executable(path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).unwrap();
+}
+
+#[test]
+#[serial]
+fn find_gui_binary_returns_none_when_absent() {
+    let _temp_dir = setup();
+
+    // Isolate from the real $PATH so a developer's own gitehr-gui install
+    // can't make this test flaky.
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    unsafe { std::env::set_var("PATH", "") };
+
+    assert!(find_gui_binary().is_none());
+
+    unsafe { std::env::set_var("PATH", original_path) };
+}
+
+#[test]
+#[serial]
+fn find_gui_binary_prefers_bundled_path() {
+    let temp_dir = setup();
+
+    fs::create_dir_all(".gitehr").unwrap();
+    fs::write(".gitehr/gitehr-gui", b"fake binary").unwrap();
+
+    let found = find_gui_binary().expect("bundled binary should be found");
+    assert_eq!(found, std::path::Path::new(".gitehr/gitehr-gui"));
+
+    drop(temp_dir);
+}
+
+#[test]
+#[serial]
+#[cfg(unix)]
+fn find_gui_binary_falls_back_to_path() {
+    let temp_dir = setup();
+
+    let bin_dir = tempdir().unwrap();
+    let bin_path = bin_dir.path().join("gitehr-gui");
+    fs::write(&bin_path, b"#!/bin/sh\n").unwrap();
+    make_executable(&bin_path);
+
+    let original_path = prepend_to_path(bin_dir.path());
+
+    let found = find_gui_binary().expect("PATH binary should be found");
+    assert_eq!(found, bin_path);
+
+    unsafe { std::env::set_var("PATH", original_path) };
+    drop(temp_dir);
+}

--- a/cli/tests/commands/mod.rs
+++ b/cli/tests/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod contributor;
 pub mod demographics;
 pub mod document;
 pub mod encrypt;
+pub mod gui;
 pub mod journal;
 pub mod mcp;
 #[cfg(unix)]

--- a/spec/roadmap.md
+++ b/spec/roadmap.md
@@ -20,7 +20,7 @@ Legend: `[x]` done, `[~]` in progress, `[ ]` not started. This roadmap lists out
 
 - [ ] **R6 - Extend Store identifier operations:** add `search`, `link`, `unlink`, `merge`, and `path`, plus the `GITEHR_MPI_PATH` override, as `gitehr store` subcommands.
 - [~] **R7 - Document the self-hoster on-ramp:** make families, carers, and pet owners first-class audiences in site and GUI onboarding, alongside clinics (ADR-0005). Site homepage done (families/carers folded into "For Patients & Families", plus a new "For Pet Owners" card); GUI onboarding has no onboarding flow yet to update (tracked by R63).
-- [ ] **R8 - Align GUI launch behaviour:** prefer the bundled `.gitehr/gitehr-gui`, then `gitehr-gui` on `$PATH`, rather than the current development launcher.
+- [x] **R8 - Align GUI launch behaviour:** prefer the bundled `.gitehr/gitehr-gui`, then `gitehr-gui` on `$PATH`, rather than the current development launcher.
 
 ## GUI and TUI
 


### PR DESCRIPTION
## Summary

Implements roadmap item **R8 - Align GUI launch behaviour**.

`gitehr gui` unconditionally shelled out to `npm run tauri dev`, ignoring the `find_gui_binary()` helper that already existed as dead code. This wires it up so the command:

- Prefers a bundled binary at `.gitehr/gitehr-gui` (or `.gitehr/gitehr-gui.exe` on Windows).
- Falls back to `gitehr-gui` on `$PATH`.
- Prints install/build guidance if neither is found.

This matches the behaviour already documented in `docs/cli/gui.md` and `spec/commands/gui.md` — the docs were ahead of the code. Development use moves to the existing `s/gui-dev` script, which already runs the dev-mode command directly, so nothing is lost for contributors running from source.

## Changes

- `cli/src/commands/gui.rs`: `run()` now calls `find_gui_binary()` and branches on the result instead of always invoking `npm run tauri dev`.
- `cli/tests/commands/gui.rs`: new integration tests covering the bundled-path, `$PATH`-fallback, and not-found cases for `find_gui_binary()`.
- `spec/roadmap.md`: marks R8 as done.

## Test plan

- [x] `cargo build -p gitehr`
- [x] `cargo test -p gitehr --test mod` (110 passed, 3 pre-existing ignored)
- [x] `cargo test -p gitehr --lib` (24 passed)
- [x] `cargo clippy -p gitehr --all-targets` (clean)
- [x] `cargo fmt --check -p gitehr` (clean)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuEzrhmPgWmb3CrHAvg8WN)_