### PR TITLE
chore(deps): update WebdriverIO Mocha framework

### DIFF
--- a/gui/e2e/package-lock.json
+++ b/gui/e2e/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@wdio/cli": "^9.30.1",
         "@wdio/local-runner": "^9.30.1",
-        "@wdio/mocha-framework": "^9.30.0",
+        "@wdio/mocha-framework": "^9.30.1",
         "@wdio/spec-reporter": "^9.30.1"
       }
     },
@@ -1543,17 +1543,17 @@
       }
     },
     "node_modules/@wdio/mocha-framework": {
-      "version": "9.30.0",
-      "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-9.30.0.tgz",
-      "integrity": "sha512-NhxHeIFd0iHpb8sud3ahOilE/bgm5MBBzSq+xSKW+hTUYdmeyy4w+KX5p/+AQ0dsUEIToaA4xjZRUTCwY+65Wg==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-9.30.1.tgz",
+      "integrity": "sha512-wGklhggr0kTMk6yDynCE+sdIQg+oSaHTDXWyXk0p0AGOjhTbm3sedg2fzawJLs/ecYjYS0VqPw/0JrBsWi3AaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.11.28",
         "@wdio/logger": "9.29.1",
-        "@wdio/types": "9.29.1",
-        "@wdio/utils": "9.30.0",
+        "@wdio/types": "9.30.1",
+        "@wdio/utils": "9.30.1",
         "mocha": "^10.3.0"
       },
       "engines": {
@@ -1578,39 +1578,13 @@
       }
     },
     "node_modules/@wdio/mocha-framework/node_modules/@wdio/types": {
-      "version": "9.29.1",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.29.1.tgz",
-      "integrity": "sha512-jp8jgMv6TS35G96YzHZxw3PVN0Dz6xQ6tnMAicndAJ8Jt9AIXb0ywIse4TjaFywakO3dLoEhlyA3ZtR26vmt+w==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.30.1.tgz",
+      "integrity": "sha512-umKQDbSmu3/ucUsIA5UUTK5gCWnClyVpWz3fC39044rCXQ3zCd1a3GoJibbAITKiwnPFf2yU3LvTa+C78sh9Lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/@wdio/utils": {
-      "version": "9.30.0",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.30.0.tgz",
-      "integrity": "sha512-MhTx8jKOtspogeMUmASFsmL6vRetwCpvfcAFHauYZ62UzPjFwHThIXorzoG90mrcS9Yl+c8Sj9BfX+bdxwXfsg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@puppeteer/browsers": "^2.2.0",
-        "@wdio/logger": "9.29.1",
-        "@wdio/types": "9.29.1",
-        "decamelize": "^6.0.0",
-        "deepmerge-ts": "^7.0.3",
-        "edgedriver": "^6.1.2",
-        "geckodriver": "^6.1.1",
-        "get-port": "^7.0.0",
-        "import-meta-resolve": "^4.0.0",
-        "locate-app": "^2.2.24",
-        "mitt": "^3.0.1",
-        "safaridriver": "^1.0.0",
-        "split2": "^4.2.0",
-        "wait-port": "^1.1.0"
       },
       "engines": {
         "node": ">=18.20.0"
@@ -1631,23 +1605,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/reporter": {
-      "version": "9.23.3",
-      "resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-9.23.3.tgz",
-      "integrity": "sha512-ObIvV+FydWGsvt7kqRBCq5ItAzWhWiWG63t5P0mQKrADCtuJMjrI0Y/IrYQzcv2KnYcmkMKOQLwXFWp8D+D/OA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0",
-        "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.23.3",
-        "diff": "^8.0.2",
-        "object-inspect": "^1.12.0"
       },
       "engines": {
         "node": ">=18.20.0"
@@ -1772,19 +1729,6 @@
       "version": "9.30.1",
       "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.30.1.tgz",
       "integrity": "sha512-umKQDbSmu3/ucUsIA5UUTK5gCWnClyVpWz3fC39044rCXQ3zCd1a3GoJibbAITKiwnPFf2yU3LvTa+C78sh9Lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/types": {
-      "version": "9.23.3",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.23.3.tgz",
-      "integrity": "sha512-Ufjh06DAD7cGTMORUkq5MTZLw1nAgBSr2y8OyiNNuAfPGCwHEU3EwEfhG/y0V7S7xT5pBxliqWi7AjRrCgGcIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/gui/e2e/package.json
+++ b/gui/e2e/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@wdio/cli": "^9.30.1",
     "@wdio/local-runner": "^9.30.1",
-    "@wdio/mocha-framework": "^9.30.0",
+    "@wdio/mocha-framework": "^9.30.1",
     "@wdio/spec-reporter": "^9.30.1"
   }
 }


### PR DESCRIPTION
Bumps `@wdio/mocha-framework` from 9.30.0 to 9.30.1 in `/gui/e2e`.

Recreated from current `main`. The Dependabot PR for this bump (#139) was based on a `main` predating #136 and #137, so its `gui/e2e/package-lock.json` conflicted. Lockfile here was regenerated with `npm install` against current `main`, so it carries the already-merged `@wdio/cli` and `@wdio/local-runner` at ^9.30.1.

Supersedes #139.