### PR TITLE
docs(spec): close command-reference gaps in the CLI overview

### DIFF
--- a/spec/commands/completions.md
+++ b/spec/commands/completions.md
@@ -1,0 +1,47 @@
+<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
+
+# `gitehr completions`
+
+Generates shell completions for `gitehr`. Implementation: [`cli/src/commands/completions.rs`](../../cli/src/commands/completions.rs).
+
+### `gitehr completions install [--shell <shell>] [--dir <dir>]`
+
+Writes a completion script to the default (or given) completion directory for the current user.
+
+Behaviour:
+
+- Shell defaults to whatever `$SHELL` points at (`bash`, `zsh`, `fish`, or `elvish`); pass `--shell` when it can't be detected (e.g. `powershell`, or `$SHELL` unset).
+- Directory defaults per shell when `--dir`/`-d` is omitted:
+  - `bash`: `$XDG_DATA_HOME/bash-completion/completions` (falls back to `~/.local/share/...`)
+  - `zsh`: `~/.zfunc`
+  - `fish`: `$XDG_CONFIG_HOME/fish/completions` (falls back to `~/.config/...`)
+  - `powershell`: `~/.config/powershell/completions`
+  - `elvish`: `~/.elvish/lib`
+- Creates the directory if it doesn't exist, and writes the completion file (e.g. `_gitehr` for zsh, `gitehr.fish` for fish).
+- Prints the path written, plus a shell-specific note: zsh needs its `fpath` updated before `compinit`, PowerShell needs the script dot-sourced from the profile; other shells just need a restart.
+
+### `gitehr completions <shell> [--dir <dir>]`
+
+Generates a completion script for `<shell>` (`bash`, `zsh`, `fish`, `powershell`, or `elvish`).
+
+Behaviour:
+
+- With `--dir`, writes the completion file into that directory (same filenames as `install`).
+- Without `--dir`, prints the completion script to stdout, for manual redirection.
+
+## Examples
+
+```bash
+$ gitehr completions install
+Completion script written to: /home/user/.zfunc/_gitehr
+Add this before `compinit` in ~/.zshrc if it is not already there:
+  fpath=(/home/user/.zfunc $fpath)
+Then restart zsh or run `autoload -Uz compinit && compinit`.
+
+$ gitehr completions zsh --dir ~/.zfunc
+Completion script written to: /home/user/.zfunc/_gitehr
+
+$ gitehr completions bash > ~/.local/share/bash-completion/completions/gitehr
+```
+
+Restart your shell after installing completions.

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -62,6 +62,8 @@ GitEHR supports extensibility through a plugin system. Any executable named `git
 - `gitehr plugins` lists all available plugins by scanning `$PATH` for `gitehr-*` executables
 - `gitehr --help` displays both built-in commands and available plugins
 
+See [`gitehr plugins`](commands/plugin.md) for the full command-resolution order and authoring notes.
+
 **Plugin authoring guidelines:**
 - Plugins should implement `--help` flag for usage information
 - Exit codes: 0 for success, non-zero for errors
@@ -83,9 +85,29 @@ Manages local machine configuration, including the default Store path used by th
 
 Adds a new clinical document to the GitEHR repository.
 
+### [`gitehr document`](commands/document.md)
+
+Attaches and verifies source Documents (scans, photos, and other files referenced from journal entries). Alias: `attach`.
+
+### [`gitehr import`](commands/import.md)
+
+Imports journal entries or documents from another GitEHR instance, in `--mode journal` or `--mode documents`.
+
 ### [`gitehr state`](commands/state.md)
 
 Manages the mutable clinical state files within the GitEHR repository.
+
+### [`gitehr allergies`](commands/allergies.md)
+
+Manages the typed allergy and adverse-reaction summary in `state/allergies.md`.
+
+### [`gitehr demographics`](commands/demographics.md)
+
+Manages typed patient demographics state.
+
+### [`gitehr vaccinations`](commands/vaccinations.md)
+
+Manages typed vaccination and immunisation state. Aliases: `immunisations`, `immunizations`.
 
 ### [`gitehr remote`](commands/remote.md)
 
@@ -109,7 +131,11 @@ Adds, enables, disables, activates, or deactivates users for the GitEHR record.
 
 ### [`gitehr mpi`](commands/mpi.md)
 
-Resolves and manages patient identifiers against a local Main Patient Index (MPI).
+Design page for identifier-resolution operations (`search`, `link`, `unlink`, `merge`, `path`) against the local Main Patient Index (MPI). Per [ADR-0005](adr/0005-store-first-model.md), these are not a separate `gitehr mpi` command - they fold into `gitehr store` (tracked as [`R6`](roadmap.md)).
+
+### [`gitehr mcp`](mcp.md)
+
+Runs the built-in Model Context Protocol server (`gitehr mcp serve --stdio`), exposing repository resources and tools to MCP-aware clients. See [`mcp.md`](mcp.md) for the full protocol design; parts of it (e.g. TCP/HTTP transports, token auth) remain roadmap items.
 
 ### [`gitehr gui`](commands/gui.md)
 
@@ -126,6 +152,10 @@ Updates the bundled binary in `.gitehr/gitehr` to match the current CLI version.
 ### [`gitehr version`](commands/version.md)
 
 Displays the current GitEHR version shared by the CLI and GUI.
+
+### [`gitehr completions`](commands/completions.md)
+
+Generates and installs shell completions for `gitehr` (bash, zsh, fish, powershell, elvish).
 
 ---
 


### PR DESCRIPTION
## Summary

Nightly triage fallback task (roadmap **R43**, "Keep command documentation aligned with runtime behaviour"). No open PRs existed to triage tonight, so I audited `spec/spec.md`'s CLI Overview index against the actual `Commands` enum in `cli/src/main.rs` and found it had drifted:

- `document`, `import`, `allergies`, `demographics`, and `vaccinations` already had full command docs under `spec/commands/` but were never linked from the overview index.
- `completions` is a fully implemented top-level command (`gitehr completions install|<shell>`) with **no doc page at all** — added `spec/commands/completions.md`, verified against `gitehr completions --help` and a real `gitehr completions install` run (default directories, shell detection, install notes all checked).
- `gitehr mpi` was listed in the index as if it were a live command; it isn't — per [ADR-0005](https://github.com/gitehr/gitehr/blob/main/spec/adr/0005-store-first-model.md) the identifier-resolution design folds into `gitehr store` (tracked as R6). Reworded that entry to match `spec/commands/mpi.md`'s own superseded notice.
- `gitehr mcp` (present in the CLI, backed by a ~1,100-line server implementation) was also missing from the index — added an entry pointing at `spec/mcp.md`, noting that transports/auth beyond stdio remain roadmap items.
- Linked `spec/commands/plugin.md` from the "Plugin System" section, which previously described plugin resolution without pointing at its own reference doc.

Left `spec/mcp.md` itself untouched — it's a 692-line design doc and a full audit of it is bigger than one nightly fallback task warrants. Didn't check off R43 in the roadmap since it's phrased as an ongoing responsibility, not a one-time deliverable.

## Test plan

- [x] `cargo build -p gitehr --bin gitehr` — builds clean.
- [x] `gitehr completions --help`, `gitehr completions install --help`, and a real `gitehr completions install` run (fake `$HOME`) — output matches the new doc page.
- [x] Confirmed every new/changed link in `spec/spec.md` resolves to an existing file.
- [x] `spec/` is not part of the mkdocs/zensical site build (`docs/` is), so no site build applies here.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01RC39oJvAdynwVXgkdy4nRM


---
_Generated by [Claude Code](https://claude.ai/code/session_01RC39oJvAdynwVXgkdy4nRM)_